### PR TITLE
implement `swap_` rpc service to allow for fetching of current/past swap statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ETH-XMR Atomic Swaps
 
-This is a WIP prototype of ETH<->XMR atomic swaps, currently in the early development phase. It currently consists of a single `atomic-swap` binary which allows for peers to discover each other over the network based on what you want to swap for, querying peers for additional info such as their desired exchange rate, and the ability to initiate and perform the entire protocol. The `atomic-swap` program has a JSON-RPC endpoint which the user can use to interact with the process. 
+This is a WIP implementation of ETH-XMR atomic swaps, currently in the pre-production development phase. It currently consists of `swapd` and `swapcli` binaries, the swap daemon and swap CLI tool respectively, which allow for peers to discover each other over the network, query peers for their current available offers, and the ability to make and take swap offers and perform the swap protocol. The `swapd` program has a JSON-RPC endpoint which the user can use to interact with it. `swapcli` is a command-line utility that interacts with `swapd` by performing RPC calls. 
 
 ## Disclaimer
 
@@ -121,57 +121,24 @@ Query the returned peer as to how much XMR they can provide and their preferred 
 Now, we can tell Alice to initiate the protocol w/ the peer (Bob), the offer (copy the Offer id from above), and a desired amount to swap:
 ```bash
 ./swapcli take --multiaddr /ip4/192.168.0.101/tcp/9934/p2p/12D3KooWC547RfLcveQi1vBxACjnT6Uv15V11ortDTuxRWuhubGv --offer-id cf4bf01a0775a0d13fa41b14516e4b89034300707a1754e0d99b65f6cb6fffb9 --provides-amount 0.05
-# Swap successful, received 1 ETH
+# Initiated swap with ID=0
 ```
 
 If all goes well, you should see Alice and Bob successfully exchange messages and execute the swap protocol. The result is that Alice now owns the private key to a Monero account (and is the only owner of that key) and Bob has the ETH transferred to him. On Alice's side, a Monero wallet will be generated in the `--wallet-dir` provided in the `monero-wallet-rpc` step for Alice.
 
+To query the information for an ongoing swap, you can run:
+```bash
+./swapcli get-ongoing-swap
+```
+
+To query information for a past swap using its ID, you can run:
+```bash
+./swapcli get-past-swap --id <id>
+```
+
 ### Developer instructions
 
-##### Compiling DLEq binaries
-
-To compile the farcaster-dleq binaries used, you can run:
-```
-make build-dleq
-```
-
-This will install Rust (if it isn't already installed) and build the binaries. The resulting binaries will be in `./farcaster-dleq/target/release/`.
-
-##### Compiling contract bindings
-
-If you update the `Swap.sol` contract for some reason, you will need to re-generate the Go bindings for the contract. **Note:** you do *not* need to do this to try out the swap; only if you want to edit the contract for development purposes.
-
-Download solc v0.8.9: https://github.com/ethereum/solidity/releases/tag/v0.8.9
-
-Set `SOLC_BIN` to the downloaded binary
-```
-export SOLC_BIN=solc
-```
-
-Install `abigen`
-```
-git clone https://github.com/ethereum/go-ethereum.git && cd go-ethereum/cmd/abigen
-go install
-```
-
-Generate the bindings
-```
-./scripts/generate-bindings.sh
-```
-Note: you may need to add `$GOPATH` and `$GOPATH/bin` to your path.
-
-#### Testing
-To setup the test environment and run all unit tests, execute:
-```
-make test
-```
-
-This will test the main protocol functionality on the ethereum side:
-1. Success case, where both parties obey the protocol
-2. Case where Bob never locks monero on his side. Alice can Refund
-3. Case where Bob locks monero, but never claims his ether from the contract
-
-Upon Refund/Claim by either side, they reveal the secret to the counterparty, which *always* guarantees that the counteryparty can claim the locked funds on ethereum.
+Please see the [developer docs](docs/developing.md).
 
 ## Contributions
 

--- a/cmd/client/client/swap.go
+++ b/cmd/client/client/swap.go
@@ -1,0 +1,87 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/noot/atomic-swap/common/rpcclient"
+	"github.com/noot/atomic-swap/rpc"
+)
+
+// GetPastSwapIDs calls swap_getPastIDs
+func (c *Client) GetPastSwapIDs() ([]uint64, error) {
+	const (
+		method = "swap_getPastIDs"
+	)
+
+	resp, err := rpcclient.PostRPC(c.endpoint, method, "{}")
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Error != nil {
+		return nil, fmt.Errorf("failed to call %s: %w", method, resp.Error)
+	}
+
+	var res *rpc.GetPastIDsResponse
+	if err = json.Unmarshal(resp.Result, &res); err != nil {
+		return nil, err
+	}
+
+	return res.IDs, nil
+}
+
+// GetOngoingSwap calls swap_getOngoing
+func (c *Client) GetOngoingSwap() (*rpc.GetOngoingResponse, error) {
+	const (
+		method = "swap_getOngoing"
+	)
+
+	resp, err := rpcclient.PostRPC(c.endpoint, method, "{}")
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Error != nil {
+		return nil, fmt.Errorf("failed to call %s: %w", method, resp.Error)
+	}
+
+	var res *rpc.GetOngoingResponse
+	if err = json.Unmarshal(resp.Result, &res); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+// GetPastSwap calls swap_getPast
+func (c *Client) GetPastSwap(id uint64) (*rpc.GetPastResponse, error) {
+	const (
+		method = "swap_getPast"
+	)
+
+	req := &rpc.GetPastRequest{
+		ID: id,
+	}
+
+	params, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := rpcclient.PostRPC(c.endpoint, method, string(params))
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Error != nil {
+		return nil, resp.Error
+	}
+
+	var res *rpc.GetPastResponse
+	if err = json.Unmarshal(resp.Result, &res); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}

--- a/cmd/client/client/take_offer.go
+++ b/cmd/client/client/take_offer.go
@@ -9,7 +9,7 @@ import (
 )
 
 // TakeOffer calls net_takeOffer.
-func (c *Client) TakeOffer(maddr string, offerID string, providesAmount float64) (bool, float64, error) {
+func (c *Client) TakeOffer(maddr string, offerID string, providesAmount float64) (uint64, error) {
 	const (
 		method = "net_takeOffer"
 	)
@@ -22,22 +22,22 @@ func (c *Client) TakeOffer(maddr string, offerID string, providesAmount float64)
 
 	params, err := json.Marshal(req)
 	if err != nil {
-		return false, 0, err
+		return 0, err
 	}
 
 	resp, err := rpcclient.PostRPC(c.endpoint, method, string(params))
 	if err != nil {
-		return false, 0, err
+		return 0, err
 	}
 
 	if resp.Error != nil {
-		return false, 0, fmt.Errorf("failed to call %s: %w", method, resp.Error)
+		return 0, fmt.Errorf("failed to call %s: %w", method, resp.Error)
 	}
 
 	var res *rpc.TakeOfferResponse
 	if err = json.Unmarshal(resp.Result, &res); err != nil {
-		return false, 0, err
+		return 0, err
 	}
 
-	return res.Success, res.ReceivedAmount, nil
+	return res.ID, nil
 }

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -243,16 +243,11 @@ func runTake(ctx *cli.Context) error {
 	}
 
 	c := client.NewClient(endpoint)
-	ok, received, err := c.TakeOffer(maddr, offerID, providesAmount)
+	id, err := c.TakeOffer(maddr, offerID, providesAmount)
 	if err != nil {
 		return err
 	}
 
-	if ok {
-		fmt.Printf("Swap successful, received %v ETH\n", received)
-	} else {
-		fmt.Printf("Swap failed! Please check swapd logs for additional information.")
-	}
-
+	fmt.Printf("Initiated swap with ID=%d\n", id)
 	return nil
 }

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -86,7 +86,7 @@ var (
 			{
 				Name:    "take",
 				Aliases: []string{"t"},
-				Usage:   "initiate a swap by taking an offerl currently only eth holders can be the takers",
+				Usage:   "initiate a swap by taking an offer; currently only eth holders can be the takers",
 				Action:  runTake,
 				Flags: []cli.Flag{
 					&cli.StringFlag{
@@ -100,6 +100,30 @@ var (
 					&cli.Float64Flag{
 						Name:  "provides-amount",
 						Usage: "amount of coin to send in the swap",
+					},
+					daemonAddrFlag,
+				},
+			},
+			{
+				Name:   "get-past-swap-ids",
+				Usage:  "get past swap IDs",
+				Action: runGetPastSwapIDs,
+				Flags:  []cli.Flag{daemonAddrFlag},
+			},
+			{
+				Name:   "get-ongoing-swap",
+				Usage:  "get information about ongoing swap, if there is one",
+				Action: runGetOngoingSwap,
+				Flags:  []cli.Flag{daemonAddrFlag},
+			},
+			{
+				Name:   "get-past-swap",
+				Usage:  "get information about a past swap with the given ID",
+				Action: runGetPastSwap,
+				Flags: []cli.Flag{
+					&cli.UintFlag{
+						Name:  "id",
+						Usage: "ID of swap to retrieve info for",
 					},
 					daemonAddrFlag,
 				},
@@ -249,5 +273,69 @@ func runTake(ctx *cli.Context) error {
 	}
 
 	fmt.Printf("Initiated swap with ID=%d\n", id)
+	return nil
+}
+
+func runGetPastSwapIDs(ctx *cli.Context) error {
+	endpoint := ctx.String("daemon-addr")
+	if endpoint == "" {
+		endpoint = defaultSwapdAddress
+	}
+
+	c := client.NewClient(endpoint)
+	ids, err := c.GetPastSwapIDs()
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Past swap IDs: %v\n", ids)
+	return nil
+}
+
+func runGetOngoingSwap(ctx *cli.Context) error {
+	endpoint := ctx.String("daemon-addr")
+	if endpoint == "" {
+		endpoint = defaultSwapdAddress
+	}
+
+	c := client.NewClient(endpoint)
+	info, err := c.GetOngoingSwap()
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("ID: %d\n Provided: %s\n ProvidedAmount: %v\n ReceivedAmount: %v\n ExchangeRate: %v\n Status: %s\n",
+		info.ID,
+		info.Provided,
+		info.ProvidedAmount,
+		info.ReceivedAmount,
+		info.ExchangeRate,
+		info.Status,
+	)
+	return nil
+}
+
+func runGetPastSwap(ctx *cli.Context) error {
+	id := ctx.Uint("id")
+
+	endpoint := ctx.String("daemon-addr")
+	if endpoint == "" {
+		endpoint = defaultSwapdAddress
+	}
+
+	c := client.NewClient(endpoint)
+	info, err := c.GetPastSwap(uint64(id))
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("ID: %d\n Provided: %s\n ProvidedAmount: %v\n ReceivedAmount: %v\n ExchangeRate: %v\n Status: %s\n",
+		id,
+		info.Provided,
+		info.ProvidedAmount,
+		info.ReceivedAmount,
+		info.ExchangeRate,
+		info.Status,
+	)
 	return nil
 }

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -1,0 +1,46 @@
+# Developing 
+
+## Compiling DLEq binaries
+
+The program utilizes a Rust DLEq library implemented by Farcaster.
+
+To compile the farcaster-dleq binaries used, you can run:
+```
+make build-dleq
+```
+
+This will install Rust (if it isn't already installed) and build the binaries. The resulting binaries will be in `./farcaster-dleq/target/release/`.
+
+## Compiling contract bindings
+
+If you update the `Swap.sol` contract for some reason, you will need to re-generate the Go bindings for the contract. **Note:** you do *not* need to do this to try out the swap; only if you want to edit the contract for development purposes.
+
+Download solc v0.8.9: https://github.com/ethereum/solidity/releases/tag/v0.8.9
+
+Set `SOLC_BIN` to the downloaded binary
+```
+export SOLC_BIN=solc
+```
+
+Install `abigen`
+```
+git clone https://github.com/ethereum/go-ethereum.git && cd go-ethereum/cmd/abigen
+go install
+```
+
+Generate the bindings
+```
+./scripts/generate-bindings.sh
+```
+Note: you may need to add `$GOPATH` and `$GOPATH/bin` to your path.
+
+## Testing
+To setup the test environment and run all unit tests, execute:
+```
+make test
+```
+
+This include tests for main protocol functionality, such as:
+1. Success case, where both parties obey the protocol
+2. Case where Bob never locks monero on his side. Alice can Refund
+3. Case where Bob locks monero, but never claims his ether from the contract

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -130,3 +130,69 @@ curl -X POST http://127.0.0.1:5002 -d '{"jsonrpc":"2.0","id":"0","method":"perso
 ```
 {"jsonrpc":"2.0","result":null,"id":"0"}
 ```
+
+## `swap` namespace
+
+### `swap_getOngoing`
+
+Gets information about the ongoing swap, if there is one.
+
+Parameters:
+- none
+
+Returns:
+- `id`: the swap's ID. **Note: this is not the same as an offer ID.**
+- `provided`: the coin provided during the swap.
+- `providedAmount`: the amount of coin provided during the swap.
+- `receivedAmount`: the amount of coin expected to be received during the swap.
+- `exchangeRate`: the exchange rate of the swap, expressed in a ratio of XMR/ETH.
+- `status`: the swap's status; should always be "ongoing".
+
+Example:
+```
+curl -X POST http://127.0.0.1:5001 -d '{"jsonrpc":"2.0","id":"0","method":"swap_getOngoing","params":{}}' -H 'Content-Type: application/json'
+```
+```
+{"jsonrpc":"2.0","result":{"ID":3,"provided":"ETH","providedAmount":0.05,"receivedAmount":0,"exchangeRate":0,"status":"ongoing"},"id":"0"}
+```
+
+### `swap_getPastIDs`
+
+Gets all past swap IDs.
+
+Parameters:
+- none
+
+Returns:
+- `ids`: a list of all past swap IDs.
+
+Example:
+```
+curl -X POST http://127.0.0.1:5001 -d '{"jsonrpc":"2.0","id":"0","method":"swap_getPastIDs","params":{}}' -H 'Content-Type: application/json'
+```
+
+```
+{"jsonrpc":"2.0","result":{"ids":[2,3,0,1]},"id":"0"}
+```
+
+### `swap_getPast`
+
+Gets a past swap information for the given swap ID.
+
+Paramters:
+- `id`: the swap ID.
+
+Returns:
+- `provided`: the coin provided during the swap.
+- `providedAmount`: the amount of coin provided during the swap.
+- `receivedAmount`: the amount of coin received during the swap.
+- `exchangeRate`: the exchange rate of the swap, expressed in a ratio of XMR/ETH.
+- `status`: the swap's status, one of `success`, `refunded`, or `aborted`.
+
+```
+curl -X POST http://127.0.0.1:5001 -d '{"jsonrpc":"2.0","id":"0","method":"swap_getPast","params":{"id": 0}}' -H 'Content-Type: application/json'
+```
+
+```
+{"jsonrpc":"2.0","result":{"provided":"ETH","providedAmount":0.05,"receivedAmount":1,"exchangeRate":20,"status":"success"},"id":"0"}
+```

--- a/net/host.go
+++ b/net/host.go
@@ -237,7 +237,7 @@ func (h *host) writeToStream(s libp2pnetwork.Stream, msg Message) error {
 	}
 
 	log.Debug(
-		"Sent message to peer=", s.Conn().RemotePeer(), " message=", msg.String(),
+		"Sent message to peer=", s.Conn().RemotePeer(), " type=", msg.Type(),
 	)
 
 	return nil

--- a/net/initiate.go
+++ b/net/initiate.go
@@ -33,14 +33,13 @@ type SwapState interface {
 
 	// used by RPC
 	SendKeysMessage() (*SendKeysMessage, error)
-	ReceivedAmount() float64
+	ID() uint64
 }
 
 func (h *host) Initiate(who peer.AddrInfo, msg *SendKeysMessage, s SwapState) error {
 	h.swapMu.Lock()
 	defer h.swapMu.Unlock()
 
-	// TODO: need a lock for this, otherwise two streams can enter this func
 	if h.swapState != nil {
 		return errors.New("already have ongoing swap")
 	}
@@ -67,7 +66,7 @@ func (h *host) Initiate(who peer.AddrInfo, msg *SendKeysMessage, s SwapState) er
 	}
 
 	h.swapState = s
-	h.handleProtocolStreamInner(stream)
+	go h.handleProtocolStreamInner(stream)
 	return nil
 }
 

--- a/net/initiate.go
+++ b/net/initiate.go
@@ -116,7 +116,7 @@ func (h *host) handleProtocolStreamInner(stream libp2pnetwork.Stream) {
 		}
 
 		log.Debug(
-			"received message from peer, peer=", stream.Conn().RemotePeer(), " msg=", msg.String(),
+			"received message from peer, peer=", stream.Conn().RemotePeer(), " type=", msg.Type(),
 		)
 
 		var (

--- a/net/message.go
+++ b/net/message.go
@@ -8,8 +8,11 @@ import (
 	"github.com/noot/atomic-swap/common/types"
 )
 
+// MessageType represents the type of a network message
+type MessageType byte
+
 const (
-	QueryResponseType byte = iota //nolint
+	QueryResponseType MessageType = iota //nolint
 	SendKeysMessageType
 	NotifyContractDeployedType
 	NotifyXMRLockType
@@ -18,11 +21,30 @@ const (
 	NotifyRefundType
 )
 
+func (t MessageType) String() string {
+	switch t {
+	case QueryResponseType:
+		return "QueryResponse"
+	case SendKeysMessageType:
+		return "SendKeysMessage"
+	case NotifyContractDeployedType:
+		return "NotifyContractDeployed"
+	case NotifyXMRLockType:
+		return "NotifyXMRLock"
+	case NotifyClaimedType:
+		return "NotifyClaimed"
+	case NotifyRefundType:
+		return "NotifyRefund"
+	default:
+		return "unknown"
+	}
+}
+
 // Message must be implemented by all network messages
 type Message interface {
 	String() string
 	Encode() ([]byte, error)
-	Type() byte
+	Type() MessageType
 }
 
 func decodeMessage(b []byte) (Message, error) {
@@ -30,7 +52,7 @@ func decodeMessage(b []byte) (Message, error) {
 		return nil, errors.New("invalid message bytes")
 	}
 
-	switch b[0] {
+	switch MessageType(b[0]) {
 	case QueryResponseType:
 		var m *QueryResponse
 		if err := json.Unmarshal(b[1:], &m); err != nil {
@@ -91,11 +113,11 @@ func (m *QueryResponse) Encode() ([]byte, error) {
 		return nil, err
 	}
 
-	return append([]byte{QueryResponseType}, b...), nil
+	return append([]byte{byte(QueryResponseType)}, b...), nil
 }
 
 // Type ...
-func (m *QueryResponse) Type() byte {
+func (m *QueryResponse) Type() MessageType {
 	return QueryResponseType
 }
 
@@ -135,11 +157,11 @@ func (m *SendKeysMessage) Encode() ([]byte, error) {
 		return nil, err
 	}
 
-	return append([]byte{SendKeysMessageType}, b...), nil
+	return append([]byte{byte(SendKeysMessageType)}, b...), nil
 }
 
 // Type ...
-func (m *SendKeysMessage) Type() byte {
+func (m *SendKeysMessage) Type() MessageType {
 	return SendKeysMessageType
 }
 
@@ -161,11 +183,11 @@ func (m *NotifyContractDeployed) Encode() ([]byte, error) {
 		return nil, err
 	}
 
-	return append([]byte{NotifyContractDeployedType}, b...), nil
+	return append([]byte{byte(NotifyContractDeployedType)}, b...), nil
 }
 
 // Type ...
-func (m *NotifyContractDeployed) Type() byte {
+func (m *NotifyContractDeployed) Type() MessageType {
 	return NotifyContractDeployedType
 }
 
@@ -186,11 +208,11 @@ func (m *NotifyXMRLock) Encode() ([]byte, error) {
 		return nil, err
 	}
 
-	return append([]byte{NotifyXMRLockType}, b...), nil
+	return append([]byte{byte(NotifyXMRLockType)}, b...), nil
 }
 
 // Type ...
-func (m *NotifyXMRLock) Type() byte {
+func (m *NotifyXMRLock) Type() MessageType {
 	return NotifyXMRLockType
 }
 
@@ -209,11 +231,11 @@ func (m *NotifyReady) Encode() ([]byte, error) {
 		return nil, err
 	}
 
-	return append([]byte{NotifyReadyType}, b...), nil
+	return append([]byte{byte(NotifyReadyType)}, b...), nil
 }
 
 // Type ...
-func (m *NotifyReady) Type() byte {
+func (m *NotifyReady) Type() MessageType {
 	return NotifyReadyType
 }
 
@@ -234,11 +256,11 @@ func (m *NotifyClaimed) Encode() ([]byte, error) {
 		return nil, err
 	}
 
-	return append([]byte{NotifyClaimedType}, b...), nil
+	return append([]byte{byte(NotifyClaimedType)}, b...), nil
 }
 
 // Type ...
-func (m *NotifyClaimed) Type() byte {
+func (m *NotifyClaimed) Type() MessageType {
 	return NotifyClaimedType
 }
 
@@ -259,10 +281,10 @@ func (m *NotifyRefund) Encode() ([]byte, error) {
 		return nil, err
 	}
 
-	return append([]byte{NotifyRefundType}, b...), nil
+	return append([]byte{byte(NotifyRefundType)}, b...), nil
 }
 
 // Type ...
-func (m *NotifyRefund) Type() byte {
+func (m *NotifyRefund) Type() MessageType {
 	return NotifyRefundType
 }

--- a/protocol/alice/instance.go
+++ b/protocol/alice/instance.go
@@ -13,6 +13,7 @@ import (
 	"github.com/noot/atomic-swap/common"
 	"github.com/noot/atomic-swap/monero"
 	"github.com/noot/atomic-swap/net"
+	"github.com/noot/atomic-swap/protocol/swap"
 
 	logging "github.com/ipfs/go-log"
 )
@@ -43,6 +44,8 @@ type Instance struct {
 	// non-nil if a swap is currently happening, nil otherwise
 	swapMu    sync.Mutex
 	swapState *swapState
+
+	swapManager *swap.Manager
 }
 
 // Config contains the configuration values for a new Alice instance.
@@ -56,6 +59,7 @@ type Config struct {
 	ChainID              int64
 	GasPrice             *big.Int
 	GasLimit             uint64
+	SwapManager          *swap.Manager
 }
 
 // NewInstance returns a new instance of Alice.
@@ -86,7 +90,8 @@ func NewInstance(cfg *Config) (*Instance, error) {
 			From:    crypto.PubkeyToAddress(*pub),
 			Context: cfg.Ctx,
 		},
-		chainID: big.NewInt(cfg.ChainID),
+		chainID:     big.NewInt(cfg.ChainID),
+		swapManager: cfg.SwapManager,
 	}, nil
 }
 

--- a/protocol/alice/message_handler.go
+++ b/protocol/alice/message_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/noot/atomic-swap/monero"
 	"github.com/noot/atomic-swap/net"
 	pcommon "github.com/noot/atomic-swap/protocol"
+	pswap "github.com/noot/atomic-swap/protocol/swap"
 	"github.com/noot/atomic-swap/swap-contract"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
@@ -51,7 +52,7 @@ func (s *swapState) HandleProtocolMessage(msg net.Message) (net.Message, bool, e
 
 		close(s.claimedCh)
 		log.Info("successfully created monero wallet from our secrets: address=", address)
-		s.success = true
+		s.info.SetStatus(pswap.Success)
 		return nil, true, nil
 	default:
 		return nil, false, errors.New("unexpected message type")
@@ -68,7 +69,7 @@ func (s *swapState) checkMessageType(msg net.Message) error {
 
 func (s *swapState) handleSendKeysMessage(msg *net.SendKeysMessage) (net.Message, error) {
 	// TODO: get user to confirm amount they will receive!!
-	s.desiredAmount = common.MoneroToPiconero(msg.ProvidedAmount)
+	s.info.SetReceivedAmount(msg.ProvidedAmount)
 	log.Infof(color.New(color.Bold).Sprintf("you will be receiving %v XMR", msg.ProvidedAmount))
 
 	if msg.PublicSpendKey == "" || msg.PrivateViewKey == "" {
@@ -100,7 +101,7 @@ func (s *swapState) handleSendKeysMessage(msg *net.SendKeysMessage) (net.Message
 	}
 
 	s.setBobKeys(sk, vk, secp256k1Pub)
-	address, err := s.deployAndLockETH(s.providesAmount)
+	address, err := s.deployAndLockETH(s.providedAmountInWei())
 	if err != nil {
 		return nil, fmt.Errorf("failed to deploy contract: %w", err)
 	}
@@ -222,9 +223,9 @@ func (s *swapState) handleNotifyXMRLock(msg *net.NotifyXMRLock) (net.Message, er
 	log.Debugf("checking locked wallet, address=%s balance=%v", kp.Address(s.alice.env), balance.Balance)
 
 	// TODO: also check that the balance isn't unlocked only after an unreasonable amount of blocks
-	if balance.Balance < float64(s.desiredAmount) {
+	if balance.Balance < float64(s.receivedAmountInPiconero()) {
 		return nil, fmt.Errorf("locked XMR amount is less than expected: got %v, expected %v",
-			balance.Balance, float64(s.desiredAmount))
+			balance.Balance, float64(s.receivedAmountInPiconero()))
 	}
 
 	if err := s.alice.client.CloseWallet(); err != nil {

--- a/protocol/alice/message_handler.go
+++ b/protocol/alice/message_handler.go
@@ -72,6 +72,9 @@ func (s *swapState) handleSendKeysMessage(msg *net.SendKeysMessage) (net.Message
 	s.info.SetReceivedAmount(msg.ProvidedAmount)
 	log.Infof(color.New(color.Bold).Sprintf("you will be receiving %v XMR", msg.ProvidedAmount))
 
+	exchangeRate := msg.ProvidedAmount / s.info.ProvidedAmount()
+	s.info.SetExchangeRate(common.ExchangeRate(exchangeRate))
+
 	if msg.PublicSpendKey == "" || msg.PrivateViewKey == "" {
 		return nil, errMissingKeys
 	}

--- a/protocol/alice/net.go
+++ b/protocol/alice/net.go
@@ -47,7 +47,7 @@ func (a *Instance) initiate(providesAmount common.EtherAmount) error {
 		return err
 	}
 
-	log.Info(color.New(color.Bold).Sprintf("**initiated swap with ID=%d**", a.swapState.id))
+	log.Info(color.New(color.Bold).Sprintf("**initiated swap with ID=%d**", a.swapState.info.ID()))
 	log.Info(color.New(color.Bold).Sprint("DO NOT EXIT THIS PROCESS OR FUNDS MAY BE LOST!"))
 	return nil
 }

--- a/protocol/alice/swap_state.go
+++ b/protocol/alice/swap_state.go
@@ -117,6 +117,11 @@ func (s *swapState) ReceivedAmount() float64 {
 	return s.desiredAmount.AsMonero()
 }
 
+// ID returns the ID of the swap
+func (s *swapState) ID() uint64 {
+	return s.id
+}
+
 // ProtocolExited is called by the network when the protocol stream closes.
 // If it closes prematurely, we need to perform recovery.
 func (s *swapState) ProtocolExited() error {

--- a/protocol/bob/instance.go
+++ b/protocol/bob/instance.go
@@ -15,6 +15,7 @@ import (
 	"github.com/noot/atomic-swap/common"
 	"github.com/noot/atomic-swap/monero"
 	"github.com/noot/atomic-swap/net"
+	"github.com/noot/atomic-swap/protocol/swap"
 
 	logging "github.com/ipfs/go-log"
 )
@@ -45,6 +46,7 @@ type Instance struct {
 	net net.MessageSender
 
 	offerManager *offerManager
+	swapManager  *swap.Manager
 
 	swapMu    sync.Mutex
 	swapState *swapState
@@ -62,6 +64,7 @@ type Config struct {
 	Environment                common.Environment
 	ChainID                    int64
 	GasPrice                   *big.Int
+	SwapManager                *swap.Manager
 	GasLimit                   uint64
 }
 
@@ -120,6 +123,7 @@ func NewInstance(cfg *Config) (*Instance, error) {
 		ethAddress:   addr,
 		chainID:      big.NewInt(cfg.ChainID),
 		offerManager: newOfferManager(),
+		swapManager:  cfg.SwapManager,
 	}, nil
 }
 

--- a/protocol/bob/net.go
+++ b/protocol/bob/net.go
@@ -39,7 +39,7 @@ func (b *Instance) initiate(offerID types.Hash, providesAmount common.MoneroAmou
 		return err
 	}
 
-	log.Info(color.New(color.Bold).Sprintf("**initiated swap with ID=%d**", b.swapState.id))
+	log.Info(color.New(color.Bold).Sprintf("**initiated swap with ID=%d**", b.swapState.ID()))
 	log.Info(color.New(color.Bold).Sprint("DO NOT EXIT THIS PROCESS OR FUNDS MAY BE LOST!"))
 	return nil
 }

--- a/protocol/bob/recovery_test.go
+++ b/protocol/bob/recovery_test.go
@@ -24,6 +24,7 @@ func newTestRecoveryState(t *testing.T) *recoveryState {
 	addr, _ := deploySwap(t, inst, s, sr, big.NewInt(1), duration)
 	rs, err := NewRecoveryState(inst, s.privkeys.SpendKey(), addr)
 	require.NoError(t, err)
+
 	return rs
 }
 
@@ -48,11 +49,11 @@ func TestClaimOrRecover_Recover(t *testing.T) {
 	daemonClient := monero.NewClient(common.DefaultMoneroDaemonEndpoint)
 	addr, err := rs.ss.bob.client.GetAddress(0)
 	require.NoError(t, err)
-	_ = daemonClient.GenerateBlocks(addr.Address, 61)
+	_ = daemonClient.GenerateBlocks(addr.Address, 121)
 
 	// lock XMR
 	rs.ss.setAlicePublicKeys(rs.ss.pubkeys, nil)
-	addrAB, err := rs.ss.lockFunds(33000)
+	addrAB, err := rs.ss.lockFunds(333)
 	require.NoError(t, err)
 
 	// call refund w/ Alice's spend key

--- a/protocol/bob/swap_state.go
+++ b/protocol/bob/swap_state.go
@@ -88,7 +88,8 @@ func newSwapState(b *Instance, offerID types.Hash, providesAmount common.MoneroA
 	txOpts.GasLimit = b.gasLimit
 
 	exchangeRate := common.ExchangeRate(providesAmount.AsMonero() / desiredAmount.AsEther())
-	info := pswap.NewInfo(common.ProvidesXMR, providesAmount.AsMonero(), desiredAmount.AsEther(), exchangeRate, pswap.Ongoing)
+	info := pswap.NewInfo(common.ProvidesXMR, providesAmount.AsMonero(), desiredAmount.AsEther(),
+		exchangeRate, pswap.Ongoing)
 	if err := b.swapManager.AddSwap(info); err != nil {
 		return nil, err
 	}

--- a/protocol/bob/swap_state.go
+++ b/protocol/bob/swap_state.go
@@ -132,6 +132,11 @@ func (s *swapState) ReceivedAmount() float64 {
 	return s.desiredAmount.AsEther()
 }
 
+// ID returns the ID of the swap
+func (s *swapState) ID() uint64 {
+	return s.id
+}
+
 // ProtocolExited is called by the network when the protocol stream closes.
 // If it closes prematurely, we need to perform recovery.
 func (s *swapState) ProtocolExited() error {

--- a/protocol/bob/swap_state.go
+++ b/protocol/bob/swap_state.go
@@ -26,10 +26,9 @@ import (
 	"github.com/noot/atomic-swap/monero"
 	"github.com/noot/atomic-swap/net"
 	pcommon "github.com/noot/atomic-swap/protocol"
+	pswap "github.com/noot/atomic-swap/protocol/swap"
 	"github.com/noot/atomic-swap/swap-contract"
 )
-
-var nextID uint64
 
 var (
 	errMissingKeys       = errors.New("did not receive Alice's public spend or view key")
@@ -50,10 +49,8 @@ type swapState struct {
 	cancel context.CancelFunc
 	sync.Mutex
 
-	id             uint64
-	providesAmount common.MoneroAmount
-	desiredAmount  common.EtherAmount
-	offerID        types.Hash
+	info    *pswap.Info
+	offerID types.Hash
 
 	// our keys for this session
 	dleqProof    *dleq.Proof
@@ -77,9 +74,7 @@ type swapState struct {
 	// channels
 	readyCh chan struct{}
 
-	// set to true on claiming the ETH or reclaiming XMR
-	completed            bool
-	refunded             bool
+	// address of reclaimed monero wallet, if the swap is refunded
 	moneroReclaimAddress mcrypto.Address
 }
 
@@ -92,22 +87,24 @@ func newSwapState(b *Instance, offerID types.Hash, providesAmount common.MoneroA
 	txOpts.GasPrice = b.gasPrice
 	txOpts.GasLimit = b.gasLimit
 
-	ctx, cancel := context.WithCancel(b.ctx)
+	exchangeRate := common.ExchangeRate(providesAmount.AsMonero() / desiredAmount.AsEther())
+	info := pswap.NewInfo(common.ProvidesXMR, providesAmount.AsMonero(), desiredAmount.AsEther(), exchangeRate, pswap.Ongoing)
+	if err := b.swapManager.AddSwap(info); err != nil {
+		return nil, err
+	}
 
+	ctx, cancel := context.WithCancel(b.ctx)
 	s := &swapState{
 		ctx:                 ctx,
 		cancel:              cancel,
 		bob:                 b,
-		id:                  nextID,
-		providesAmount:      providesAmount,
-		desiredAmount:       desiredAmount,
 		offerID:             offerID,
 		nextExpectedMessage: &net.SendKeysMessage{},
 		readyCh:             make(chan struct{}),
 		txOpts:              txOpts,
+		info:                info,
 	}
 
-	nextID++
 	return s, nil
 }
 
@@ -118,7 +115,7 @@ func (s *swapState) SendKeysMessage() (*net.SendKeysMessage, error) {
 	}
 
 	return &net.SendKeysMessage{
-		ProvidedAmount:     s.providesAmount.AsMonero(),
+		ProvidedAmount:     s.info.ProvidedAmount(),
 		PublicSpendKey:     s.pubkeys.SpendKey().Hex(),
 		PrivateViewKey:     s.privkeys.ViewKey().Hex(),
 		DLEqProof:          hex.EncodeToString(s.dleqProof.Proof()),
@@ -129,12 +126,12 @@ func (s *swapState) SendKeysMessage() (*net.SendKeysMessage, error) {
 
 // ReceivedAmount returns the amount received, or expected to be received, at the end of the swap
 func (s *swapState) ReceivedAmount() float64 {
-	return s.desiredAmount.AsEther()
+	return s.info.ReceivedAmount()
 }
 
 // ID returns the ID of the swap
 func (s *swapState) ID() uint64 {
-	return s.id
+	return s.info.ID()
 }
 
 // ProtocolExited is called by the network when the protocol stream closes.
@@ -147,28 +144,33 @@ func (s *swapState) ProtocolExited() error {
 		// stop all running goroutines
 		s.cancel()
 		s.bob.swapState = nil
+		s.bob.swapManager.CompleteOngoingSwap()
 	}()
 
-	// TODO: defer this?
-	if s.completed {
-		str := color.New(color.Bold).Sprintf("**swap completed successfully! id=%d**", s.id)
+	if s.info.Status() == pswap.Success {
+		str := color.New(color.Bold).Sprintf("**swap completed successfully! id=%d**", s.ID())
 		log.Info(str)
 
-		if !s.refunded {
-			// remove offer, as it's been taken
-			s.bob.offerManager.deleteOffer(s.offerID)
-		}
+		// remove offer, as it's been taken
+		s.bob.offerManager.deleteOffer(s.offerID)
+		return nil
+	}
 
+	if s.info.Status() == pswap.Refunded {
+		str := color.New(color.Bold).Sprintf("**swap refunded successfully: id=%d**", s.ID())
+		log.Info(str)
 		return nil
 	}
 
 	switch s.nextExpectedMessage.(type) {
 	case *net.SendKeysMessage:
 		// we are fine, as we only just initiated the protocol.
+		s.info.SetStatus(pswap.Aborted)
 		return errors.New("protocol exited before any funds were locked")
 	case *net.NotifyContractDeployed:
 		// we were waiting for the contract to be deployed, but haven't
 		// locked out funds yet, so we're fine.
+		s.info.SetStatus(pswap.Aborted)
 		return errors.New("protocol exited before any funds were locked")
 	case *net.NotifyReady:
 		// we already locked our funds - need to wait until we can claim
@@ -189,12 +191,12 @@ func (s *swapState) ProtocolExited() error {
 			return err
 		}
 
-		s.completed = true
-		s.refunded = true // TODO: return this
+		s.info.SetStatus(pswap.Refunded)
 		s.moneroReclaimAddress = address
 		log.Infof("regained private key to monero wallet, address=%s", address)
 		return nil
 	default:
+		s.info.SetStatus(pswap.Aborted)
 		log.Errorf("unexpected nextExpectedMessage in ProtocolExited: type=%T", s.nextExpectedMessage)
 		return errors.New("unexpected message type")
 	}
@@ -220,7 +222,7 @@ func (s *swapState) reclaimMonero(skA *mcrypto.PrivateSpendKey) (mcrypto.Address
 	kpAB := mcrypto.NewPrivateKeyPair(skAB, vkAB)
 
 	// write keys to file in case something goes wrong
-	fp := fmt.Sprintf("%s/%d/swap-secret", s.bob.basepath, s.id)
+	fp := fmt.Sprintf("%s/%d/swap-secret", s.bob.basepath, s.ID())
 	if err = mcrypto.WriteKeysToFile(fp, kpAB, s.bob.env); err != nil {
 		return "", err
 	}
@@ -291,7 +293,7 @@ func (s *swapState) generateAndSetKeys() error {
 	s.privkeys = keysAndProof.PrivateKeyPair
 	s.pubkeys = keysAndProof.PublicKeyPair
 
-	fp := fmt.Sprintf("%s/%d/bob-secret", s.bob.basepath, s.id)
+	fp := fmt.Sprintf("%s/%d/bob-secret", s.bob.basepath, s.ID())
 	if err := mcrypto.WriteKeysToFile(fp, s.privkeys, s.bob.env); err != nil {
 		return err
 	}
@@ -351,8 +353,9 @@ func (s *swapState) checkContract() error {
 		return err
 	}
 
-	if balance.Cmp(s.desiredAmount.BigInt()) < 0 {
-		return fmt.Errorf("contract does not have expected balance: got %s, expected %s", balance, s.desiredAmount)
+	expected := common.EtherToWei(s.info.ProvidedAmount()).BigInt()
+	if balance.Cmp(expected) < 0 {
+		return fmt.Errorf("contract does not have expected balance: got %s, expected %s", balance, expected)
 	}
 
 	constructedTopic := ethcommon.HexToHash("0x8d36aa70807342c3036697a846281194626fd4afa892356ad5979e03831ab080")

--- a/protocol/bob/swap_state.go
+++ b/protocol/bob/swap_state.go
@@ -354,7 +354,7 @@ func (s *swapState) checkContract() error {
 		return err
 	}
 
-	expected := common.EtherToWei(s.info.ProvidedAmount()).BigInt()
+	expected := common.EtherToWei(s.info.ReceivedAmount()).BigInt()
 	if balance.Cmp(expected) < 0 {
 		return fmt.Errorf("contract does not have expected balance: got %s, expected %s", balance, expected)
 	}

--- a/protocol/swap/manager.go
+++ b/protocol/swap/manager.go
@@ -21,6 +21,21 @@ const (
 	Aborted
 )
 
+func (s Status) String() string {
+	switch s {
+	case Ongoing:
+		return "ongoing"
+	case Success:
+		return "success"
+	case Refunded:
+		return "refunded"
+	case Aborted:
+		return "aborted"
+	default:
+		return "unknown"
+	}
+}
+
 // Info contains the details of the swap as well as its status.
 type Info struct {
 	id             uint64 // ID number of the swap (not the swap offer ID!)
@@ -110,6 +125,18 @@ func (m *Manager) AddSwap(info *Info) error {
 	}
 
 	return nil
+}
+
+func (m *Manager) GetPastIDs() []uint64 {
+	m.RLock()
+	defer m.RUnlock()
+	ids := make([]uint64, len(m.past))
+	i := 0
+	for id := range m.past {
+		ids[i] = id
+		i++
+	}
+	return ids
 }
 
 func (m *Manager) GetPastSwap(id uint64) *Info {

--- a/protocol/swap/manager.go
+++ b/protocol/swap/manager.go
@@ -1,12 +1,20 @@
 package swap
 
 import (
+	"errors"
+	"sync"
+
 	"github.com/noot/atomic-swap/common"
 )
 
-type Status byte 
+var nextID uint64
 
-var (
+type Status byte
+
+const (
+	// success set to true upon a successful swap (ie. creation of the XMR wallet)
+	// refunded is set to true if the locked ether if refunded from the contract
+	// aborted is set to true if the swap aborts before any funds are locked
 	Ongoing Status = iota
 	Success
 	Refunded
@@ -15,41 +23,112 @@ var (
 
 // Info contains the details of the swap as well as its status.
 type Info struct {
-	provides common.ProvidesCoin
+	id             uint64 // ID number of the swap (not the swap offer ID!)
+	provides       common.ProvidesCoin
 	providedAmount float64
 	receivedAmount float64
-	exchangeRate common.ExchangeRate
-	status Status
+	exchangeRate   common.ExchangeRate
+	status         Status
 }
 
-func NewInfo(provides common.ProvidesCoin, providedAmount, receivedAmount float64, exchangeRate common.ExchangeRate) *Info {
-	retunr &Info{
-		provides: provides,
+func (i *Info) ID() uint64 {
+	return i.id
+}
+
+func (i *Info) Provides() common.ProvidesCoin {
+	return i.provides
+}
+
+func (i *Info) ProvidedAmount() float64 {
+	return i.providedAmount
+}
+
+func (i *Info) ReceivedAmount() float64 {
+	return i.receivedAmount
+}
+
+func (i *Info) ExchangeRate() common.ExchangeRate {
+	return i.exchangeRate
+}
+
+func (i *Info) Status() Status {
+	return i.status
+}
+
+func (i *Info) SetReceivedAmount(a float64) {
+	i.receivedAmount = a
+}
+
+func (i *Info) SetExchangeRate(r common.ExchangeRate) {
+	i.exchangeRate = r
+}
+
+func (i *Info) SetStatus(s Status) {
+	i.status = s
+}
+
+func NewInfo(provides common.ProvidesCoin, providedAmount, receivedAmount float64,
+	exchangeRate common.ExchangeRate, status Status) *Info {
+	info := &Info{
+		id:             nextID,
+		provides:       provides,
 		providedAmount: providedAmount,
 		receivedAmount: receivedAmount,
-		exchangeRate: exchangeRate,
+		exchangeRate:   exchangeRate,
+		status:         status,
 	}
-}
-
-func (i *Info) SetStatus(status Status) {
-	i.status = status
+	nextID++
+	return info
 }
 
 // Manager tracks current and past swaps.
 type Manager struct {
-	swaps map[uint64]*info
+	sync.RWMutex
+	ongoing *Info
+	past    map[uint64]*Info
 }
 
 func NewManager() *Manager {
 	return &Manager{
-		swaps: make(map[uint64]*info),
+		past: make(map[uint64]*Info),
 	}
 }
 
-func (m *Manager) AddSwap(id uint64, info *Info) {
-	m.swaps[id] = info
+func (m *Manager) AddSwap(info *Info) error {
+	m.Lock()
+	defer m.Unlock()
+
+	switch info.status {
+	case Ongoing:
+		if m.ongoing != nil {
+			return errors.New("already have ongoing swap")
+		}
+
+		m.ongoing = info
+	default:
+		m.past[info.id] = info
+	}
+
+	return nil
 }
 
-func (m *Manager) GetSwap(id uint64) *Info {
-	return m.swaps[id]
+func (m *Manager) GetPastSwap(id uint64) *Info {
+	m.RLock()
+	defer m.RUnlock()
+	return m.past[id]
+}
+
+func (m *Manager) GetOngoingSwap() *Info {
+	return m.ongoing
+}
+
+func (m *Manager) CompleteOngoingSwap() {
+	m.Lock()
+	defer m.Unlock()
+	if m.ongoing == nil {
+		return
+	}
+
+	m.past[m.ongoing.id] = m.ongoing
+	m.ongoing = nil
 }

--- a/protocol/swap/manager.go
+++ b/protocol/swap/manager.go
@@ -1,0 +1,55 @@
+package swap
+
+import (
+	"github.com/noot/atomic-swap/common"
+)
+
+type Status byte 
+
+var (
+	Ongoing Status = iota
+	Success
+	Refunded
+	Aborted
+)
+
+// Info contains the details of the swap as well as its status.
+type Info struct {
+	provides common.ProvidesCoin
+	providedAmount float64
+	receivedAmount float64
+	exchangeRate common.ExchangeRate
+	status Status
+}
+
+func NewInfo(provides common.ProvidesCoin, providedAmount, receivedAmount float64, exchangeRate common.ExchangeRate) *Info {
+	retunr &Info{
+		provides: provides,
+		providedAmount: providedAmount,
+		receivedAmount: receivedAmount,
+		exchangeRate: exchangeRate,
+	}
+}
+
+func (i *Info) SetStatus(status Status) {
+	i.status = status
+}
+
+// Manager tracks current and past swaps.
+type Manager struct {
+	swaps map[uint64]*info
+}
+
+func NewManager() *Manager {
+	return &Manager{
+		swaps: make(map[uint64]*info),
+	}
+}
+
+func (m *Manager) AddSwap(id uint64, info *Info) {
+	m.swaps[id] = info
+}
+
+func (m *Manager) GetSwap(id uint64) *Info {
+	return m.swaps[id]
+}

--- a/protocol/swap/manager.go
+++ b/protocol/swap/manager.go
@@ -9,18 +9,21 @@ import (
 
 var nextID uint64
 
+// Status represents the status of a swap.
 type Status byte
 
 const (
-	// success set to true upon a successful swap (ie. creation of the XMR wallet)
-	// refunded is set to true if the locked ether if refunded from the contract
-	// aborted is set to true if the swap aborts before any funds are locked
+	// Ongoing represents an ongoing swap.
 	Ongoing Status = iota
+	// Success represents a successful swap.
 	Success
+	// Refunded represents a swap that was refunded.
 	Refunded
+	// Aborted represents the case where the swap aborts before any funds are locked.
 	Aborted
 )
 
+// String ...
 func (s Status) String() string {
 	switch s {
 	case Ongoing:
@@ -46,42 +49,60 @@ type Info struct {
 	status         Status
 }
 
+// ID returns the swap ID.
 func (i *Info) ID() uint64 {
+	if i == nil {
+		return 0
+	}
+
 	return i.id
 }
 
+// Provides returns the coin that was provided for this swap.
 func (i *Info) Provides() common.ProvidesCoin {
 	return i.provides
 }
 
+// ProvidedAmount returns the amount of coin provided for this swap, in standard units.
 func (i *Info) ProvidedAmount() float64 {
 	return i.providedAmount
 }
 
+// ReceivedAmount returns the amount of coin received for this swap, in standard units.
 func (i *Info) ReceivedAmount() float64 {
 	return i.receivedAmount
 }
 
+// ExchangeRate returns the exchange rate for this swap, represented by a ratio of XMR/ETH.
 func (i *Info) ExchangeRate() common.ExchangeRate {
 	return i.exchangeRate
 }
 
+// Status returns the swap's status.
 func (i *Info) Status() Status {
 	return i.status
 }
 
+// SetReceivedAmount ...
 func (i *Info) SetReceivedAmount(a float64) {
 	i.receivedAmount = a
 }
 
+// SetExchangeRate ...
 func (i *Info) SetExchangeRate(r common.ExchangeRate) {
 	i.exchangeRate = r
 }
 
+// SetStatus ...
 func (i *Info) SetStatus(s Status) {
+	if i == nil {
+		return
+	}
+
 	i.status = s
 }
 
+// NewInfo ...
 func NewInfo(provides common.ProvidesCoin, providedAmount, receivedAmount float64,
 	exchangeRate common.ExchangeRate, status Status) *Info {
 	info := &Info{
@@ -103,12 +124,14 @@ type Manager struct {
 	past    map[uint64]*Info
 }
 
+// NewManager ...
 func NewManager() *Manager {
 	return &Manager{
 		past: make(map[uint64]*Info),
 	}
 }
 
+// AddSwap adds the given swap *Info to the Manager.
 func (m *Manager) AddSwap(info *Info) error {
 	m.Lock()
 	defer m.Unlock()
@@ -127,6 +150,7 @@ func (m *Manager) AddSwap(info *Info) error {
 	return nil
 }
 
+// GetPastIDs returns all past swap IDs.
 func (m *Manager) GetPastIDs() []uint64 {
 	m.RLock()
 	defer m.RUnlock()
@@ -139,16 +163,19 @@ func (m *Manager) GetPastIDs() []uint64 {
 	return ids
 }
 
+// GetPastSwap returns a swap's *Info given its ID.
 func (m *Manager) GetPastSwap(id uint64) *Info {
 	m.RLock()
 	defer m.RUnlock()
 	return m.past[id]
 }
 
+// GetOngoingSwap returns the ongoing swap's *Info, if there is one.
 func (m *Manager) GetOngoingSwap() *Info {
 	return m.ongoing
 }
 
+// CompleteOngoingSwap marks the current ongoing swap as completed.
 func (m *Manager) CompleteOngoingSwap() {
 	m.Lock()
 	defer m.Unlock()

--- a/rpc/net.go
+++ b/rpc/net.go
@@ -128,10 +128,8 @@ type TakeOfferRequest struct {
 }
 
 // TakeOfferResponse ...
-// TODO: add Refunded bool
 type TakeOfferResponse struct {
-	Success        bool    `json:"success"`
-	ReceivedAmount float64 `json:"receivedAmount"`
+	ID uint64 `json:"id"`
 }
 
 // TakeOffer initiates a swap with the given peer by taking an offer they've made.
@@ -155,12 +153,10 @@ func (s *NetService) TakeOffer(_ *http.Request, req *TakeOfferRequest, resp *Tak
 	}
 
 	if err = s.net.Initiate(who, skm, swapState); err != nil {
-		resp.Success = false
 		return err
 	}
 
-	resp.Success = true
-	resp.ReceivedAmount = swapState.ReceivedAmount()
+	resp.ID = swapState.ID()
 	return nil
 }
 

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -44,6 +44,10 @@ func NewServer(cfg *Config) (*Server, error) {
 		return nil, err
 	}
 
+	if err := s.RegisterService(NewSwapService(cfg.SwapManager), "swap"); err != nil {
+		return nil, err
+	}
+
 	return &Server{
 		s:    s,
 		port: cfg.Port,
@@ -90,6 +94,7 @@ type Bob interface {
 
 // SwapManager ...
 type SwapManager interface {
+	GetPastIDs() []uint64
 	GetPastSwap(id uint64) *swap.Info
 	GetOngoingSwap() *swap.Info
 }

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -7,6 +7,7 @@ import (
 	"github.com/noot/atomic-swap/common"
 	"github.com/noot/atomic-swap/common/types"
 	"github.com/noot/atomic-swap/net"
+	"github.com/noot/atomic-swap/protocol/swap"
 
 	"github.com/gorilla/mux"
 	"github.com/gorilla/rpc/v2"
@@ -24,10 +25,11 @@ type Server struct {
 
 // Config ...
 type Config struct {
-	Port  uint16
-	Net   Net
-	Alice Alice
-	Bob   Bob
+	Port        uint16
+	Net         Net
+	Alice       Alice
+	Bob         Bob
+	SwapManager SwapManager
 }
 
 // NewServer ...
@@ -84,4 +86,10 @@ type Bob interface {
 	Protocol
 	MakeOffer(offer *types.Offer) error
 	SetMoneroWalletFile(file, password string) error
+}
+
+// SwapManager ...
+type SwapManager interface {
+	GetPastSwap(id uint64) *swap.Info
+	GetOngoingSwap() *swap.Info
 }

--- a/rpc/swap.go
+++ b/rpc/swap.go
@@ -1,0 +1,86 @@
+package rpc
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/noot/atomic-swap/common"
+)
+
+// SwapService handles information about ongoing or past swaps.
+type SwapService struct {
+	sm SwapManager
+}
+
+// NewSwapService ...
+func NewSwapService(sm SwapManager) *SwapService {
+	return &SwapService{
+		sm: sm,
+	}
+}
+
+// GetPastIDsResponse ...
+type GetPastIDsResponse struct {
+	IDs []uint64 `json:"ids"`
+}
+
+// GetPastIDs returns all past swap IDs
+func (s *SwapService) GetPastIDs(_ *http.Request, _ *interface{}, resp *GetPastIDsResponse) error {
+	resp.IDs = s.sm.GetPastIDs()
+	return nil
+}
+
+// GetPast ...
+type GetPastRequest struct {
+	ID uint64 `json:"id"`
+}
+
+// GetPastResponse ...
+type GetPastResponse struct {
+	Provided       common.ProvidesCoin `json:"provided"`
+	ProvidedAmount float64             `json:"providedAmount"`
+	ReceivedAmount float64             `json:"receivedAmount"`
+	ExchangeRate   common.ExchangeRate `json:"exchangeRate"`
+	Status         string              `json:"status"`
+}
+
+// GetPast returns information about a past swap, given its ID.
+func (s *SwapService) GetPast(_ *http.Request, req *GetPastRequest, resp *GetPastResponse) error {
+	info := s.sm.GetPastSwap(req.ID)
+	if info == nil {
+		return errors.New("unable to find swap with given ID")
+	}
+
+	resp.Provided = info.Provides()
+	resp.ProvidedAmount = info.ProvidedAmount()
+	resp.ReceivedAmount = info.ReceivedAmount()
+	resp.ExchangeRate = info.ExchangeRate()
+	resp.Status = info.Status().String()
+	return nil
+}
+
+// GetOngoingResponse ...
+type GetOngoingResponse struct {
+	ID             uint64
+	Provided       common.ProvidesCoin `json:"provided"`
+	ProvidedAmount float64             `json:"providedAmount"`
+	ReceivedAmount float64             `json:"receivedAmount"`
+	ExchangeRate   common.ExchangeRate `json:"exchangeRate"`
+	Status         string              `json:"status"`
+}
+
+// GetOngoing returns information about the ongoing swap, if there is one.
+func (s *SwapService) GetOngoing(_ *http.Request, _ *interface{}, resp *GetOngoingResponse) error {
+	info := s.sm.GetOngoingSwap()
+	if info == nil {
+		return errors.New("no current ongoing swap")
+	}
+
+	resp.ID = info.ID()
+	resp.Provided = info.Provides()
+	resp.ProvidedAmount = info.ProvidedAmount()
+	resp.ReceivedAmount = info.ReceivedAmount()
+	resp.ExchangeRate = info.ExchangeRate()
+	resp.Status = info.Status().String()
+	return nil
+}

--- a/rpc/swap.go
+++ b/rpc/swap.go
@@ -30,7 +30,7 @@ func (s *SwapService) GetPastIDs(_ *http.Request, _ *interface{}, resp *GetPastI
 	return nil
 }
 
-// GetPast ...
+// GetPastRequest ...
 type GetPastRequest struct {
 	ID uint64 `json:"id"`
 }

--- a/rpc/swap.go
+++ b/rpc/swap.go
@@ -61,7 +61,7 @@ func (s *SwapService) GetPast(_ *http.Request, req *GetPastRequest, resp *GetPas
 
 // GetOngoingResponse ...
 type GetOngoingResponse struct {
-	ID             uint64
+	ID             uint64              `json:"id"`
 	Provided       common.ProvidesCoin `json:"provided"`
 	ProvidedAmount float64             `json:"providedAmount"`
 	ReceivedAmount float64             `json:"receivedAmount"`

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -204,5 +204,5 @@ func TestAlice_TakeOffer(t *testing.T) {
 
 	id, err := c.TakeOffer(providers[0][0], offerID, 0.1)
 	require.NoError(t, err)
-	require.Equal(t, 0, id)
+	require.Equal(t, uint64(0), id)
 }

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -188,11 +188,11 @@ func TestAlice_Query(t *testing.T) {
 	require.Equal(t, exchangeRate, float64(resp.Offers[0].ExchangeRate))
 }
 
-func TestAlice_Initiate(t *testing.T) {
+func TestAlice_TakeOffer(t *testing.T) {
 	startNodes(t)
 
 	bc := client.NewClient(defaultBobDaemonEndpoint)
-	id, err := bc.MakeOffer(0.1, bobProvideAmount, exchangeRate)
+	offerID, err := bc.MakeOffer(0.1, bobProvideAmount, exchangeRate)
 	require.NoError(t, err)
 
 	c := client.NewClient(defaultAliceDaemonEndpoint)
@@ -202,8 +202,7 @@ func TestAlice_Initiate(t *testing.T) {
 	require.Equal(t, 1, len(providers))
 	require.GreaterOrEqual(t, len(providers[0]), 2)
 
-	ok, received, err := c.TakeOffer(providers[0][0], id, 0.1)
+	id, err := c.TakeOffer(providers[0][0], offerID, 0.1)
 	require.NoError(t, err)
-	require.True(t, ok)
-	require.Equal(t, float64(0.1)/exchangeRate, received)
+	require.Equal(t, 0, id)
 }


### PR DESCRIPTION
closes #71

- implement `swap_getPastIDs`
- implement `swap_getPast`
- implement `swap_getOngoing`
- update `net_takeOffer` to return swap ID on swap initiation (instead of success bool on completion)

todo:
- [x] update swapcli
- [x] update rpc docs
- [x] update readme