### PR TITLE
check that XMR amount peer will send is same as expected 

### DIFF
--- a/net/message/message.go
+++ b/net/message/message.go
@@ -15,7 +15,7 @@ type Type byte
 const (
 	QueryResponseType Type = iota //nolint
 	SendKeysType
-	NotifyETHLockedType // TODO: rename to NotifyETHLockType
+	NotifyETHLockedType
 	NotifyXMRLockType
 	NotifyReadyType
 	NotifyClaimedType

--- a/protocol/alice/message_handler.go
+++ b/protocol/alice/message_handler.go
@@ -152,6 +152,8 @@ func (s *swapState) handleSendKeysMessage(msg *net.SendKeysMessage) (net.Message
 		const timeoutBuffer = time.Second * 5
 		until := time.Until(s.t0)
 
+		log.Debugf("time until refund: %ds", until.Seconds())
+
 		select {
 		case <-s.ctx.Done():
 			return

--- a/protocol/alice/message_handler.go
+++ b/protocol/alice/message_handler.go
@@ -172,6 +172,21 @@ func (s *swapState) handleSendKeysMessage(msg *net.SendKeysMessage) (net.Message
 
 			log.Infof("got our ETH back: tx hash=%s", txhash)
 
+			if s == nil {
+				log.Error("swap state is nil")
+				return
+			}
+
+			if s.alice == nil {
+				log.Error("s.alice is nil")
+				return
+			}
+
+			if s.alice.net == nil {
+				log.Error("s.alice.net is nil")
+				return
+			}
+
 			// send NotifyRefund msg
 			if err := s.alice.net.SendSwapMessage(&message.NotifyRefund{
 				TxHash: txhash.String(),

--- a/protocol/alice/net_test.go
+++ b/protocol/alice/net_test.go
@@ -3,12 +3,16 @@ package alice
 import (
 	"testing"
 
+	"github.com/noot/atomic-swap/common/types"
+
 	"github.com/stretchr/testify/require"
 )
 
 func TestAlice_InitiateProtocol(t *testing.T) {
 	a := newTestAlice(t)
-	s, err := a.InitiateProtocol(3.33)
+	s, err := a.InitiateProtocol(3.33, &types.Offer{
+		ExchangeRate: 1,
+	})
 	require.NoError(t, err)
 	require.Equal(t, a.swapState, s)
 }

--- a/protocol/alice/recovery_test.go
+++ b/protocol/alice/recovery_test.go
@@ -2,6 +2,7 @@ package alice
 
 import (
 	"testing"
+	"time"
 
 	"github.com/noot/atomic-swap/common"
 
@@ -11,6 +12,7 @@ import (
 
 func newTestRecoveryState(t *testing.T) *recoveryState {
 	inst, s := newTestInstance(t)
+	inst.swapTimeout = time.Second * 10
 	akp, err := generateKeys()
 	require.NoError(t, err)
 

--- a/protocol/alice/swap_state_test.go
+++ b/protocol/alice/swap_state_test.go
@@ -243,6 +243,7 @@ func TestSwapState_NotifyXMRLock_Refund(t *testing.T) {
 func TestSwapState_NotifyClaimed(t *testing.T) {
 	_, s := newTestInstance(t)
 	defer s.cancel()
+	s.alice.swapTimeout = time.Minute * 2
 
 	s.alice.client = monero.NewClient(common.DefaultBobMoneroEndpoint)
 	err := s.alice.client.OpenWallet("test-wallet", "")

--- a/protocol/alice/swap_state_test.go
+++ b/protocol/alice/swap_state_test.go
@@ -71,9 +71,8 @@ func newTestAlice(t *testing.T) *Instance {
 
 func newTestInstance(t *testing.T) (*Instance, *swapState) {
 	alice := newTestAlice(t)
-	swapState, err := newSwapState(alice, infofile, common.NewEtherAmount(1))
+	swapState, err := newSwapState(alice, infofile, common.NewEtherAmount(1), common.MoneroAmount(0), 1)
 	require.NoError(t, err)
-	swapState.info.SetReceivedAmount(1)
 	return alice, swapState
 }
 
@@ -173,7 +172,6 @@ func TestSwapState_NotifyXMRLock(t *testing.T) {
 	err = s.lockETH(common.NewEtherAmount(1))
 	require.NoError(t, err)
 
-	s.info.SetReceivedAmount(0)
 	kp := mcrypto.SumSpendAndViewKeys(bobKeysAndProof.PublicKeyPair, s.pubkeys)
 	xmrAddr := kp.Address(common.Mainnet)
 
@@ -209,7 +207,6 @@ func TestSwapState_NotifyXMRLock_Refund(t *testing.T) {
 	err = s.lockETH(common.NewEtherAmount(1))
 	require.NoError(t, err)
 
-	s.info.SetReceivedAmount(0)
 	kp := mcrypto.SumSpendAndViewKeys(bobKeysAndProof.PublicKeyPair, s.pubkeys)
 	xmrAddr := kp.Address(common.Mainnet)
 
@@ -282,7 +279,6 @@ func TestSwapState_NotifyClaimed(t *testing.T) {
 	_ = daemonClient.GenerateBlocks(bobAddr.Address, 60)
 
 	amt := common.MoneroAmount(1)
-	s.info.SetReceivedAmount(amt.AsMonero())
 	kp := mcrypto.SumSpendAndViewKeys(s.pubkeys, s.pubkeys)
 	xmrAddr := kp.Address(common.Mainnet)
 

--- a/protocol/alice/swap_state_test.go
+++ b/protocol/alice/swap_state_test.go
@@ -267,7 +267,7 @@ func TestSwapState_NotifyClaimed(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, done)
 	require.NotNil(t, resp)
-	require.Equal(t, defaultTimeoutDuration, s.t1.Sub(s.t0))
+	require.Equal(t, time.Minute*2, s.t1.Sub(s.t0))
 	require.Equal(t, msg.PublicSpendKey, s.bobPublicSpendKey.Hex())
 	require.Equal(t, msg.PrivateViewKey, s.bobPrivateViewKey.Hex())
 

--- a/protocol/bob/swap_state_test.go
+++ b/protocol/bob/swap_state_test.go
@@ -72,7 +72,7 @@ func newTestBob(t *testing.T) *Instance {
 	bobAddr, err := bob.client.GetAddress(0)
 	require.NoError(t, err)
 
-	_ = bob.daemonClient.GenerateBlocks(bobAddr.Address, 256)
+	_ = bob.daemonClient.GenerateBlocks(bobAddr.Address, 512)
 	err = bob.client.Refresh()
 	require.NoError(t, err)
 	return bob

--- a/protocol/swap/manager.go
+++ b/protocol/swap/manager.go
@@ -70,16 +70,6 @@ func (i *Info) StatusCh() <-chan types.Status {
 	return i.statusCh
 }
 
-// SetReceivedAmount ...
-func (i *Info) SetReceivedAmount(a float64) {
-	i.receivedAmount = a
-}
-
-// SetExchangeRate ...
-func (i *Info) SetExchangeRate(r types.ExchangeRate) {
-	i.exchangeRate = r
-}
-
 // SetStatus ...
 func (i *Info) SetStatus(s Status) {
 	if i == nil {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -114,7 +114,7 @@ type Protocol interface {
 // Alice ...
 type Alice interface {
 	Protocol
-	InitiateProtocol(providesAmount float64) (common.SwapState, error)
+	InitiateProtocol(providesAmount float64, offer *types.Offer) (common.SwapState, error)
 	Refund() (ethcommon.Hash, error)
 	SetSwapTimeout(timeout time.Duration)
 }

--- a/rpc/ws_test.go
+++ b/rpc/ws_test.go
@@ -86,7 +86,7 @@ func (*mockAlice) SetGasPrice(gasPrice uint64) {}
 func (*mockAlice) GetOngoingSwapState() common.SwapState {
 	return new(mockSwapState)
 }
-func (*mockAlice) InitiateProtocol(providesAmount float64) (common.SwapState, error) {
+func (*mockAlice) InitiateProtocol(providesAmount float64, _ *types.Offer) (common.SwapState, error) {
 	return new(mockSwapState), nil
 }
 func (*mockAlice) Refund() (ethcommon.Hash, error) {


### PR DESCRIPTION
update Alice (ETH holder) to accept a `*types.Offer` when initiating the swap, so that she can check that the amount the counterparty claims they will send in the `*SendKeysMessage` is what she expected to receive.

closes #98