### PR TITLE
Fix double locks

### DIFF
--- a/protocol/xmrmaker/message_handler.go
+++ b/protocol/xmrmaker/message_handler.go
@@ -202,14 +202,8 @@ func (s *swapState) handleNotifyETHLocked(msg *message.NotifyETHLocked) (net.Mes
 }
 
 func (s *swapState) handleT0Expired() {
-	doExit := false
 	s.lockState()
-	defer func() {
-		s.unlockState()
-		if doExit {
-			_ = s.Exit()
-		}
-	}()
+	defer s.unlockState()
 
 	if !s.info.Status().IsOngoing() {
 		// swap was already completed, just return
@@ -221,7 +215,9 @@ func (s *swapState) handleT0Expired() {
 	if err != nil {
 		log.Errorf("failed to claim: err=%s", err)
 		// TODO: retry claim, depending on error
-		doExit = true
+		if err = s.exit(); err != nil {
+			log.Errorf("exit failed: err=%s", err)
+		}
 		return
 	}
 

--- a/protocol/xmrmaker/message_handler.go
+++ b/protocol/xmrmaker/message_handler.go
@@ -23,8 +23,8 @@ func (s *swapState) HandleProtocolMessage(msg net.Message) (net.Message, bool, e
 		return nil, true, errNilSwapState
 	}
 
-	s.Lock()
-	defer s.Unlock()
+	s.lockState()
+	defer s.unlockState()
 
 	if s.ctx.Err() != nil {
 		return nil, true, fmt.Errorf("protocol exited: %w", s.ctx.Err())
@@ -184,39 +184,14 @@ func (s *swapState) handleNotifyETHLocked(msg *message.NotifyETHLocked) (net.Mes
 
 	go func() {
 		until := time.Until(s.t0)
-
 		log.Debugf("time until t0: %vs", until.Seconds())
 
 		select {
 		case <-s.ctx.Done():
 			return
+		// TODO: Document why we add one second
 		case <-time.After(until + time.Second):
-			s.Lock()
-			defer s.Unlock()
-
-			if !s.info.Status().IsOngoing() {
-				// swap was already completed, just return
-				return
-			}
-
-			// we can now call Claim()
-			txHash, err := s.claimFunds()
-			if err != nil {
-				log.Errorf("failed to claim: err=%s", err)
-				// TODO: retry claim, depending on error
-				_ = s.exit()
-				return
-			}
-
-			log.Debug("funds claimed!")
-			s.clearNextExpectedMessage(types.CompletedSuccess)
-
-			// send *message.NotifyClaimed
-			if err := s.SendSwapMessage(&message.NotifyClaimed{
-				TxHash: txHash.String(),
-			}, s.ID()); err != nil {
-				log.Errorf("failed to send NotifyClaimed message: err=%s", err)
-			}
+			s.handleT0Expired()
 		case <-s.readyCh:
 			return
 		}
@@ -224,6 +199,40 @@ func (s *swapState) handleNotifyETHLocked(msg *message.NotifyETHLocked) (net.Mes
 
 	s.setNextExpectedMessage(&message.NotifyReady{})
 	return out, nil
+}
+
+func (s *swapState) handleT0Expired() {
+	doExit := false
+	s.lockState()
+	defer func() {
+		s.unlockState()
+		if doExit {
+			_ = s.Exit()
+		}
+	}()
+
+	if !s.info.Status().IsOngoing() {
+		// swap was already completed, just return
+		return
+	}
+
+	// we can now call Claim()
+	txHash, err := s.claimFunds()
+	if err != nil {
+		log.Errorf("failed to claim: err=%s", err)
+		// TODO: retry claim, depending on error
+		doExit = true
+		return
+	}
+
+	log.Debug("funds claimed!")
+	s.clearNextExpectedMessage(types.CompletedSuccess)
+
+	// send *message.NotifyClaimed
+	notifyClaimed := &message.NotifyClaimed{TxHash: txHash.String()}
+	if err := s.SendSwapMessage(notifyClaimed, s.ID()); err != nil {
+		log.Errorf("failed to send NotifyClaimed message: err=%s", err)
+	}
 }
 
 func (s *swapState) handleSendKeysMessage(msg *net.SendKeysMessage) error {

--- a/protocol/xmrmaker/swap_state.go
+++ b/protocol/xmrmaker/swap_state.go
@@ -150,7 +150,7 @@ func (s *swapState) ID() types.Hash {
 
 // Exit is called by the network when the protocol stream closes, or if the swap_refund RPC endpoint is called.
 // It exists the swap by refunding if necessary. If no locking has been done, it simply aborts the swap.
-// If the swap already completed successfully, this function does not doing anything in regards to the protoco.
+// If the swap already completed successfully, this function does not do anything regarding the protocol.
 func (s *swapState) Exit() error {
 	if s == nil {
 		return errNilSwapState
@@ -161,6 +161,7 @@ func (s *swapState) Exit() error {
 	return s.exit()
 }
 
+// exit is the same as Exit, but assumes the calling code block already holds the swapState lock.
 func (s *swapState) exit() error {
 	if s == nil {
 		return errNilSwapState

--- a/protocol/xmrmaker/swap_state.go
+++ b/protocol/xmrmaker/swap_state.go
@@ -40,9 +40,9 @@ var (
 type swapState struct {
 	backend.Backend
 
-	ctx    context.Context
-	cancel context.CancelFunc
-	sync.Mutex
+	ctx      context.Context
+	cancel   context.CancelFunc
+	stateMu  sync.Mutex
 	infoFile string
 
 	info         *pswap.Info
@@ -109,6 +109,14 @@ func newSwapState(b backend.Backend, offer *types.Offer, om *offerManager, statu
 	return s, nil
 }
 
+func (s *swapState) lockState() {
+	s.stateMu.Lock()
+}
+
+func (s *swapState) unlockState() {
+	s.stateMu.Unlock()
+}
+
 // SendKeysMessage ...
 func (s *swapState) SendKeysMessage() (*net.SendKeysMessage, error) {
 	if err := s.generateAndSetKeys(); err != nil {
@@ -148,8 +156,8 @@ func (s *swapState) Exit() error {
 		return errNilSwapState
 	}
 
-	s.Lock()
-	defer s.Unlock()
+	s.lockState()
+	defer s.unlockState()
 	return s.exit()
 }
 

--- a/protocol/xmrtaker/message_handler.go
+++ b/protocol/xmrtaker/message_handler.go
@@ -297,9 +297,9 @@ func (s *swapState) handleNotifyXMRLock(msg *message.NotifyXMRLock) (net.Message
 		case <-s.ctx.Done():
 			return
 		// TODO: document why we add one second
-		case <-time.After(until + 5*time.Second):
+		case <-time.After(until + time.Second):
 			s.handleT1Expired()
-			_ = s.Exit()
+			return
 		case <-s.claimedCh:
 			return
 		}
@@ -332,6 +332,10 @@ func (s *swapState) handleT1Expired() {
 		TxHash: txhash.String(),
 	}, s.ID()); err != nil {
 		log.Errorf("failed to send refund message: err=%s", err)
+	}
+
+	if err = s.exit(); err != nil {
+		log.Errorf("exit failed: err=%s", err)
 	}
 }
 

--- a/protocol/xmrtaker/swap_state.go
+++ b/protocol/xmrtaker/swap_state.go
@@ -33,9 +33,10 @@ const revertSwapCompleted = "swap is already completed"
 // and its current state.
 type swapState struct {
 	backend.Backend
-	ctx    context.Context
-	cancel context.CancelFunc
-	sync.Mutex
+
+	ctx          context.Context
+	cancel       context.CancelFunc
+	stateMu      sync.Mutex
 	infoFile     string
 	transferBack bool
 
@@ -117,6 +118,14 @@ func newSwapState(b backend.Backend, offerID types.Hash, infofile string, transf
 	return s, nil
 }
 
+func (s *swapState) lockState() {
+	s.stateMu.Lock()
+}
+
+func (s *swapState) unlockState() {
+	s.stateMu.Unlock()
+}
+
 func (s *swapState) waitForSendKeysMessage() {
 	waitDuration := time.Minute
 	timer := time.After(waitDuration)
@@ -174,10 +183,10 @@ func (s *swapState) ID() types.Hash {
 
 // Exit is called by the network when the protocol stream closes, or if the swap_refund RPC endpoint is called.
 // It exists the swap by refunding if necessary. If no locking has been done, it simply aborts the swap.
-// If the swap already completed successfully, this function does not doing anything in regards to the protoco.
+// If the swap already completed successfully, this function does not do anything regarding the protocol.
 func (s *swapState) Exit() error {
-	s.Lock()
-	defer s.Unlock()
+	s.lockState()
+	defer s.unlockState()
 
 	if s.exited {
 		return nil

--- a/protocol/xmrtaker/swap_state.go
+++ b/protocol/xmrtaker/swap_state.go
@@ -187,11 +187,14 @@ func (s *swapState) ID() types.Hash {
 func (s *swapState) Exit() error {
 	s.lockState()
 	defer s.unlockState()
+	return s.exit()
+}
 
+// exit is the same as Exit, but assumes the calling code block already holds the swapState lock.
+func (s *swapState) exit() error {
 	if s.exited {
 		return nil
 	}
-
 	s.exited = true
 
 	defer func() {

--- a/protocol/xmrtaker/swap_state_test.go
+++ b/protocol/xmrtaker/swap_state_test.go
@@ -313,7 +313,7 @@ func TestSwapState_NotifyClaimed(t *testing.T) {
 	require.NoError(t, err)
 
 	// mine some blocks to get xmr first
-	err = maker.GenerateBlocks(xmrmakerAddr.Address, 60)
+	err = maker.GenerateBlocks(xmrmakerAddr.Address, 121)
 	require.NoError(t, err)
 	err = maker.Refresh()
 	require.NoError(t, err)

--- a/recover/recovery_test.go
+++ b/recover/recovery_test.go
@@ -158,15 +158,11 @@ func TestRecoverer_RecoverFromXMRMakerSecretAndContract_Claim(t *testing.T) {
 }
 
 func TestRecoverer_RecoverFromXMRMakerSecretAndContract_Claim_afterTimeout(t *testing.T) {
-	// if testing.Short() {
-	// 	t.Skip() // TODO: fails on CI with "no contract code at address"
-	// }
-
 	keys, err := pcommon.GenerateKeysAndProof()
 	require.NoError(t, err)
 
 	claimKey := keys.Secp256k1PublicKey.Keccak256()
-	addr, contract, swapID, swap := newSwap(t, claimKey, [32]byte{}, false)
+	addr, contract, swapID, swap := newSwap(t, claimKey, [32]byte{}, true)
 	b := newBackend(t, addr, contract, tests.GetMakerTestKey(t))
 
 	r := newRecoverer(t)

--- a/tests/monero_wallet_rpc.go
+++ b/tests/monero_wallet_rpc.go
@@ -28,6 +28,7 @@ func CreateWalletRPCService(t *testing.T) string {
 	t.Cleanup(func() {
 		_ = outPipe.Close()
 		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
 	})
 	scanner := bufio.NewScanner(outPipe)
 	started := false


### PR DESCRIPTION
* Fixes an issue in `handleNotifyXMRLock` where the `swapState` lock could be grabbed twice after T1 expires
* Changes the lock in both `swapState` structs to be explicit (making the code easier to audit)
* Moves the T0 and T1 expiration code into dedicated functions for readability (verses having them in long code blocks inside a switch of an inline go process)
* Increased mined blocks by `TestSwapState_NotifyClaimed` (was still flaky and occasionally running out of money with only 60 blocks)
* Reaps exited monero-wallet-rpc processes immediately instead of when testing for a package completes
* Change to `TestRecoverer_RecoverFromXMRMakerSecretAndContract_Claim_afterTimeout` to call `set_ready`