### PR TITLE
fix incorrect padding in NewPublicKeyFromBigInt

### DIFF
--- a/common/utils.go
+++ b/common/utils.go
@@ -7,12 +7,14 @@ import (
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 )
 
-// Reverse reverses the byte slice and returns it.
+// Reverse returns a copy of the slice with the bytes in reverse order
 func Reverse(s []byte) []byte {
-	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
-		s[i], s[j] = s[j], s[i]
+	l := len(s)
+	rs := make([]byte, l)
+	for i := 0; i < l; i++ {
+		rs[i] = s[l-i-1]
 	}
-	return s
+	return rs
 }
 
 // EthereumPrivateKeyToAddress returns the address associated with a private key

--- a/common/utils_test.go
+++ b/common/utils_test.go
@@ -9,12 +9,11 @@ import (
 func TestReverse(t *testing.T) {
 	in := []byte{0xa, 0xb, 0xc}
 	expected := []byte{0xc, 0xb, 0xa}
-	res := Reverse(in)
-	require.Equal(t, expected, in)
-	require.Equal(t, expected, res)
+	require.Equal(t, expected, Reverse(in))
+	require.Equal(t, []byte{0xa, 0xb, 0xc}, in) // backing array of original slice is unmodified
 
 	in2 := [3]byte{0xa, 0xb, 0xc}
-	res = Reverse(in2[:])
-	require.Equal(t, expected, in2[:])
-	require.Equal(t, expected, res)
+	require.Equal(t, expected, Reverse(in2[:]))
+	require.Equal(t, in2, [3]byte{0xa, 0xb, 0xc}) // input array is unmodified
+
 }

--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -16,7 +16,7 @@ var (
 
 // PublicKey represents a secp256k1 public key
 type PublicKey struct {
-	x, y [32]byte
+	x, y [32]byte // points stored in big-endian format
 }
 
 // NewPublicKey returns a new public key from the given (x, y) coordinates
@@ -29,10 +29,15 @@ func NewPublicKey(x, y [32]byte) *PublicKey {
 
 // NewPublicKeyFromBigInt returns a new public key from the given (x, y) coordinates
 func NewPublicKeyFromBigInt(x, y *big.Int) *PublicKey {
-	var xb, yb [32]byte
-	copy(xb[:], x.Bytes())
-	copy(yb[:], y.Bytes())
-	return NewPublicKey(xb, yb)
+	const ptSize = 32
+	var xArray, yArray [ptSize]byte
+	xSlice := x.Bytes()
+	ySlice := y.Bytes()
+	// Copying from a big-endian slice into a big-endian array, so we want padding bytes
+	// on the left if the slice is shorter than the array.
+	copy(xArray[ptSize-len(xSlice):], xSlice)
+	copy(yArray[ptSize-len(ySlice):], ySlice)
+	return NewPublicKey(xArray, yArray)
 }
 
 // NewPublicKeyFromHex returns a public key from a 64-byte hex encoded string

--- a/dleq/cgo_dleq_test.go
+++ b/dleq/cgo_dleq_test.go
@@ -1,8 +1,13 @@
 package dleq
 
 import (
+	"crypto/ecdsa"
+	"math/big"
 	"testing"
 
+	ethsecp256k1 "github.com/ethereum/go-ethereum/crypto/secp256k1"
+
+	"github.com/noot/atomic-swap/common"
 	mcrypto "github.com/noot/atomic-swap/crypto/monero"
 
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
@@ -24,4 +29,40 @@ func TestCGODLEq(t *testing.T) {
 	require.NoError(t, err)
 	ed25519Pub := sk.Public().Bytes()
 	require.Equal(t, res.ed25519Pub[:], ed25519Pub)
+}
+
+func TestProofSecretComputesVerifyPubKeys(t *testing.T) {
+	// It would be nice to increase the number of iterations, but it's pretty slow even at 128. We
+	// previously had an issue when X or Y needed at least one high order padding byte. The chance
+	// of that happening is around (1/256+1/256)=1/128, so this loop will see values like that
+	// frequently, even if it doesn't happen on every run.
+	const iterations = 128
+	for i := 0; i < iterations; i++ {
+		proof, err := (&CGODLEq{}).Prove()
+		require.NoError(t, err)
+		res, err := (&CGODLEq{}).Verify(proof)
+		require.NoError(t, err)
+
+		// The ETH library needs the secret in big-endian format, while the monero library wants it
+		// in little endian format.
+		secretLE := proof.secret[:]
+		secretBE := common.Reverse(secretLE)
+
+		// Secp256k1 check
+		ethCurve := ethsecp256k1.S256()
+		xSecret, ySecret := ethCurve.ScalarBaseMult(secretBE)
+		pubFromSecret := &ecdsa.PublicKey{Curve: ethCurve, X: xSecret, Y: ySecret}
+		xVerify := res.Secp256k1PublicKey().X()
+		yVerify := res.Secp256k1PublicKey().Y()
+		pubFromVerify := &ecdsa.PublicKey{Curve: ethCurve,
+			X: new(big.Int).SetBytes(xVerify[:]), Y: new(big.Int).SetBytes(yVerify[:]),
+		}
+		require.True(t, pubFromSecret.Equal(pubFromVerify))
+
+		// ED25519 Check
+		sk, err := mcrypto.NewPrivateSpendKey(secretLE)
+		require.NoError(t, err)
+		ed25519Pub := sk.Public().Bytes()
+		require.Equal(t, res.ed25519Pub[:], ed25519Pub)
+	}
 }

--- a/dleq/cgo_dleq_test.go
+++ b/dleq/cgo_dleq_test.go
@@ -55,11 +55,11 @@ func TestProofSecretComputesVerifyPubKeys(t *testing.T) {
 		// Secp256k1 check
 		ethCurve := ethsecp256k1.S256()
 		xPub, yPub := ethCurve.ScalarBaseMult(secretBE)
-		pubFromSecret := &ecdsa.PublicKey{Curve: ethCurve, X: xPub, Y: yPub}
-		pubFromVerify := &ecdsa.PublicKey{Curve: ethCurve,
+		ethPubFromSecret := &ecdsa.PublicKey{Curve: ethCurve, X: xPub, Y: yPub}
+		ethPubFromVerify := &ecdsa.PublicKey{Curve: ethCurve,
 			X: toBigInt(res.Secp256k1PublicKey().X()), Y: toBigInt(res.Secp256k1PublicKey().Y()),
 		}
-		require.True(t, pubFromSecret.Equal(pubFromVerify))
+		require.True(t, ethPubFromSecret.Equal(ethPubFromVerify))
 
 		// ED25519 Check
 		sk, err := mcrypto.NewPrivateSpendKey(secretLE)

--- a/monero/client.go
+++ b/monero/client.go
@@ -32,7 +32,7 @@ type client struct {
 }
 
 // NewClient returns a new monero-wallet-rpc client.
-func NewClient(endpoint string) *client { //nolint:revive
+func NewClient(endpoint string) *client {
 	return &client{
 		endpoint: endpoint,
 	}

--- a/monero/daemon.go
+++ b/monero/daemon.go
@@ -12,7 +12,7 @@ type DaemonClient interface {
 }
 
 // NewDaemonClient returns a new monerod client.
-func NewDaemonClient(endpoint string) *client { //nolint:revive
+func NewDaemonClient(endpoint string) *client {
 	return &client{
 		endpoint: endpoint,
 	}

--- a/net/host.go
+++ b/net/host.go
@@ -75,7 +75,7 @@ type Config struct {
 }
 
 // NewHost returns a new host
-func NewHost(cfg *Config) (*host, error) { //nolint:revive
+func NewHost(cfg *Config) (*host, error) {
 	if cfg.KeyFile == "" {
 		cfg.KeyFile = defaultKeyFile
 	}

--- a/protocol/xmrmaker/recovery.go
+++ b/protocol/xmrmaker/recovery.go
@@ -21,7 +21,7 @@ type recoveryState struct {
 // which has methods to either claim ether or reclaim monero from an initiated swap.
 func NewRecoveryState(b backend.Backend, basePath string, secret *mcrypto.PrivateSpendKey,
 	contractAddr ethcommon.Address,
-	contractSwapID [32]byte, contractSwap swapfactory.SwapFactorySwap) (*recoveryState, error) { //nolint:revive
+	contractSwapID [32]byte, contractSwap swapfactory.SwapFactorySwap) (*recoveryState, error) {
 	kp, err := secret.AsPrivateKeyPair()
 	if err != nil {
 		return nil, err

--- a/protocol/xmrtaker/recovery.go
+++ b/protocol/xmrtaker/recovery.go
@@ -26,7 +26,7 @@ type recoveryState struct {
 // NewRecoveryState returns a new *xmrmaker.recoveryState,
 // which has methods to either claim ether or reclaim monero from an initiated swap.
 func NewRecoveryState(b backend.Backend, basePath string, secret *mcrypto.PrivateSpendKey,
-	contractSwapID [32]byte, contractSwap swapfactory.SwapFactorySwap) (*recoveryState, error) { //nolint:revive
+	contractSwapID [32]byte, contractSwap swapfactory.SwapFactorySwap) (*recoveryState, error) {
 	kp, err := secret.AsPrivateKeyPair()
 	if err != nil {
 		return nil, err

--- a/recover/recovery.go
+++ b/recover/recovery.go
@@ -23,7 +23,7 @@ type recoverer struct {
 }
 
 // NewRecoverer ...
-func NewRecoverer(env common.Environment, moneroEndpoint, ethEndpoint string) (*recoverer, error) { //nolint:revive
+func NewRecoverer(env common.Environment, moneroEndpoint, ethEndpoint string) (*recoverer, error) {
 	ec, err := ethclient.Dial(ethEndpoint)
 	if err != nil {
 		return nil, err

--- a/scripts/install-lint.sh
+++ b/scripts/install-lint.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
+VERSION="v1.47.2"
 GOBIN="$(go env GOPATH)/bin"
 
 if [[ ! -x "${GOBIN}/golangci-lint" ]]; then
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOBIN}" v1.46.2
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOBIN}" "${VERSION}"
 fi


### PR DESCRIPTION
On occasion we were getting transactions reverted with `provided secret does not match the expected public key`. It was a padding issue when we were converting X/Y in big.Int format when X or Y had less than 32 bytes.  The array was in big endian format and we were shifting the value left by however many high order bytes were all zero. This PR fixes the issue.