### PR TITLE
implement `swap_clearOffers` endpoint for usage in integration tests

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/noot/atomic-swap/common/types"
 	"github.com/noot/atomic-swap/rpcclient"
@@ -163,6 +164,18 @@ var (
 					&cli.StringFlag{
 						Name:  "offer-id",
 						Usage: "ID of swap to retrieve info for",
+					},
+					daemonAddrFlag,
+				},
+			},
+			{
+				Name:   "clear-offers",
+				Usage:  "clear current offers. if no offer IDs are provided, clears all current offers.",
+				Action: runClearOffers,
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:  "offer-ids",
+						Usage: "a comma-separated list of offer IDs to delete",
 					},
 					daemonAddrFlag,
 				},
@@ -494,6 +507,34 @@ func runCancel(ctx *cli.Context) error {
 	}
 
 	fmt.Printf("Cancelled successfully, exit status: %s\n", resp)
+	return nil
+}
+
+func runClearOffers(ctx *cli.Context) error {
+	endpoint := ctx.String("daemon-addr")
+	if endpoint == "" {
+		endpoint = defaultSwapdAddress
+	}
+
+	c := rpcclient.NewClient(endpoint)
+
+	ids := ctx.String("offer-ids")
+	if ids == "" {
+		err := c.ClearOffers(nil)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Cleared all offers successfully.\n")
+		return nil
+	}
+
+	err := c.ClearOffers(strings.Split(ids, ","))
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Cleared offers successfully: %s\n", ids)
 	return nil
 }
 

--- a/protocol/xmrmaker/offers.go
+++ b/protocol/xmrmaker/offers.go
@@ -1,6 +1,8 @@
 package xmrmaker
 
 import (
+	"fmt"
+
 	"github.com/noot/atomic-swap/common"
 	"github.com/noot/atomic-swap/common/types"
 	pcommon "github.com/noot/atomic-swap/protocol"
@@ -88,9 +90,24 @@ func (b *Instance) GetOffers() []*types.Offer {
 	return offers
 }
 
-// ClearOffers clears all offers.
-func (b *Instance) ClearOffers() {
+// ClearOffers clears the given offers.
+// If the offer list is empty, it clears all offers.
+func (b *Instance) ClearOffers(ids []string) error {
 	b.swapMu.Lock()
 	defer b.swapMu.Unlock()
-	b.offerManager.offers = make(map[types.Hash]*offerWithExtra)
+	if len(ids) == 0 {
+		b.offerManager.offers = make(map[types.Hash]*offerWithExtra)
+		return nil
+	}
+
+	for _, id := range ids {
+		hash, err := types.HexToHash(id)
+		if err != nil {
+			return fmt.Errorf("invalid id %s: %w", id, err)
+		}
+
+		delete(b.offerManager.offers, hash)
+	}
+
+	return nil
 }

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -135,7 +135,7 @@ type XMRMaker interface {
 	MakeOffer(offer *types.Offer) (*types.OfferExtra, error)
 	SetMoneroWalletFile(file, password string) error
 	GetOffers() []*types.Offer
-	ClearOffers()
+	ClearOffers([]string) error
 }
 
 // SwapManager ...

--- a/rpc/swap.go
+++ b/rpc/swap.go
@@ -185,6 +185,16 @@ func (s *SwapService) GetOffers(_ *http.Request, _ *interface{}, resp *GetOffers
 	return nil
 }
 
+// ClearOffersRequest ...
+type ClearOffersRequest struct {
+	IDs []string `json:"ids"`
+}
+
+// ClearOffers clears the provided offers. If there are no offers provided, it clears all offers.
+func (s *SwapService) ClearOffers(_ *http.Request, req *ClearOffersRequest, _ *interface{}) error {
+	return s.xmrmaker.ClearOffers(req.IDs)
+}
+
 // CancelRequest ...
 type CancelRequest struct {
 	OfferID string `json:"id"`

--- a/rpcclient/swap.go
+++ b/rpcclient/swap.go
@@ -158,3 +158,30 @@ func (c *Client) GetStage(id string) (*rpc.GetStageResponse, error) {
 
 	return res, nil
 }
+
+// ClearOffers calls swap_clearOffers
+func (c *Client) ClearOffers(ids []string) error {
+	const (
+		method = "swap_clearOffers"
+	)
+
+	req := &rpc.ClearOffersRequest{
+		IDs: ids,
+	}
+
+	params, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+
+	resp, err := rpctypes.PostRPC(c.endpoint, method, string(params))
+	if err != nil {
+		return err
+	}
+
+	if resp.Error != nil {
+		return fmt.Errorf("failed to call %s: %w", method, resp.Error)
+	}
+
+	return nil
+}

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -13,6 +13,7 @@ MONERO_WALLET_CLI_BOB_PID=$!
 
 sleep 5
 curl http://localhost:18083/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"create_wallet","params":{"filename":"test-wallet","password":"","language":"English"}}' -H 'Content-Type: application/json'
+curl http://localhost:18083/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"open_wallet","params":{"filename":"test-wallet","password":""}}' -H 'Content-Type: application/json'
 echo
 
 echo "starting monero-wallet-rpc on port 18084..."

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -68,7 +68,10 @@ func generateBlocks(num uint) {
 
 	fmt.Println("> Generating blocks for test setup...")
 	_ = d.GenerateBlocks(xmrmakerAddr.Address, num)
-	_ = c.Refresh() // TODO: this errors w monerod v18
+	err = c.Refresh()
+	if err != nil {
+		panic(err)
+	}
 
 	fmt.Println("> Completed generating blocks.")
 }
@@ -85,10 +88,10 @@ func generateBlocksAsync() {
 	for {
 		time.Sleep(time.Second)
 		_ = d.GenerateBlocks(xmrmakerAddr.Address, 1)
-		// err = c.Refresh()
-		// if err != nil {
-		// 	panic(err)
-		// }
+		err = c.Refresh()
+		if err != nil {
+			panic(err)
+		}
 	}
 }
 


### PR DESCRIPTION
- implement `swap_clearOffers` which can clear some or all offers
- use in integration tests

i think this implicitly closes #145 also since we never actually pinned the version, lol.